### PR TITLE
Add: area, parkingzone, forbidden 엔티티 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { getConnectionOptions } from 'typeorm';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
+import { ParkingzoneModule } from './parkingzone/parkingzone.module';
+import { ForbiddenModule } from './forbidden/forbidden.module';
+import { ForbiddenModule } from './forbiddenzone/forbidden.module';
+import { AreaModule } from './area/area.module';
+import { ParkingzoneModule } from './parkingzone/parkingzone.module';
 
 @Module({
   imports: [
@@ -16,6 +21,9 @@ import { UsersModule } from './users/users.module';
     }),
     AuthModule,
     UsersModule,
+    ParkingzoneModule,
+    AreaModule,
+    ForbiddenModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/area/dto/create-area.dto.ts
+++ b/src/area/dto/create-area.dto.ts
@@ -1,0 +1,15 @@
+import { IsNumber, IsString } from 'class-validator';
+
+export class CreateAreaDto {
+  @IsNumber()
+  readonly area_id: number;
+
+  @IsString()
+  readonly area_boundary: string;
+
+  @IsString()
+  readonly area_center: string;
+
+  @IsString()
+  readonly area_coords: string;
+}

--- a/src/area/entities/area.entity.ts
+++ b/src/area/entities/area.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+import { Parkingzone } from '../../parkingzone/entities/parkingzone.entity';
+import { Forbidden } from '../../forbidden/entities/forbidden.entity';
+
+@Entity()
+export class Area {
+  @PrimaryColumn()
+  area_id: number;
+
+  @Column({ type: 'polygon' })
+  area_boundary: number;
+
+  @Column({ type: 'point' })
+  area_center: number;
+
+  @Column({ type: 'linestring' })
+  area_coords: number;
+
+/*  @OneToMany(() => Parkingzone, (parkingzone) => parkingzone.area)
+  parkingzone: Parkingzone[];
+
+  @OneToMany(() => Forbidden, (forbidden) => forbidden.area)
+  forbidden: Forbidden[];*/
+}

--- a/src/forbidden/entities/forbidden.entity.ts
+++ b/src/forbidden/entities/forbidden.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Area } from '../../area/entities/area.entity';
+
+@Entity()
+export class Forbidden {
+  @PrimaryGeneratedColumn()
+  forbidden_id: number;
+
+  @Column({ type: 'polygon' })
+  forbidden_area_boundary: number;
+
+  @Column({ type: 'linestring' })
+  forbidden_area_coords: number;
+
+/*    @ManyToOne(() => Area, (area) => area.forbidden)
+    area: Area;*/
+}

--- a/src/parkingzone/dto/create-parkingzone.dto.ts
+++ b/src/parkingzone/dto/create-parkingzone.dto.ts
@@ -1,0 +1,15 @@
+import { IsNumber } from 'class-validator';
+
+export class CreateParkingzoneDto {
+  @IsNumber()
+  parkingzone_id: number;
+
+  @IsNumber()
+  parkingzone_center_lat: number;
+
+  @IsNumber()
+  parkingzone_center_lng: number;
+
+  @IsNumber()
+  parkingzone_radius: number;
+}

--- a/src/parkingzone/entities/parkingzone.entity.ts
+++ b/src/parkingzone/entities/parkingzone.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Parkingzone {
+  @PrimaryGeneratedColumn()
+  parkingzone_id: number;
+
+  @Column({ type: 'decimal', precision: 18, scale: 10 })
+  parkingzone_center_lat: number; // 위도
+
+  @Column({ type: 'decimal', precision: 18, scale: 10 })
+  parkingzone_center_lng: number; // 경도
+
+  @Column({ type: 'float' })
+  parkingzone_radius: number;
+
+  /*  @ManyToOne(() => Area, (area) => area.parkingzone)
+    area: Area;*/
+}


### PR DESCRIPTION
<Area >
주사용? : 요청된 지점(Point) 이 지역 안에 있는지 바깥에 있는지 판단

area_id: PK, number, 행정상의 구역을 나눌때 숫자코드를 사용하여 나눔.
area_boundary: polygon
area_center: point
area_coords: linestring
parkingzone: Parkingzone[], 연관 관계
forbidden: Forbidden[], 연관 관계

(create DTO 타입 이유)
area_id: number;
area_boundary: string; 한번에 여러개의 숫자들을 받아야 하기 때문에 string 으로 처리하는 것이 편하다.
area_center: string; 콤마(,) 없이 좌표를 저장하기에는 string 으로 처리하는 것이 편하다.
area_coords: string; 한번에 여러개의 숫자들을 받아야 하기 때문에 string 으로 처리하는 것이 편하다.

-------------
<Parkingzone (할인정책)>
default : 파킹존에 반납할 때 
들어와야 하는 값: point => (X Y) 의 string

(entity 타입 이유)
해당 지점(위도, 경도)를 기준으로 요청된 지점(Point) 가 포함되어 있는지 판단.
좌표값에서 X, Y 를 뽑아쓰는 함수가 있지만 이것은 , 로 구분됨.
Point 는 , 없이 저장이 되는 데이터타입.
따로 저장해서 공식에 적용하는게 훨씬 이득.

parkingzone_id : AI PK
parkingzone_center_lat : decimal(18,10)
parkingzone_center_lng : decimal(18,10)
parkingzone_radius : float
area : Area, 연관 관계

-------------
<forbidden (벌금정책)>
들어와야 하는 값: point => (X Y) 의 string

(1) 금지구역에서 반납 : 현재 위치가 여기 안에있음?

forbidden_id: AI PK
forbidden_area_boundary: polygon
forbidden_area_coords: linestring

(2) 지역경계 바깥에서 반납 -> area 의 area_coords 사용하여 거리값 계산
