### PR TITLE
Feat: parkingzone 판단, DB 초기값 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,9 @@ import { Kickboard } from './kickboards/kickboard.entity';
 import { Area } from './area/area.entity';
 import { ForbiddenAreaModule } from './forbidden-area/forbidden-area.module';
 import { RegularPolicy } from './regular-policies/regular-policy';
+import { ParkingZoneModule } from './parking-zone/parking-zone.module';
+import { ParkingZone } from './parking-zone/parking-zone.entity';
+import { ForbiddenArea } from './forbidden-area/forbidden-area.entity';
 
 @Module({
   imports: [
@@ -22,7 +25,13 @@ import { RegularPolicy } from './regular-policies/regular-policy';
           autoLoadEntities: true,
         }),
     }),
-    TypeOrmModule.forFeature([Area, Kickboard, RegularPolicy]),
+    TypeOrmModule.forFeature([
+      Area,
+      Kickboard,
+      RegularPolicy,
+      ParkingZone,
+      ForbiddenArea,
+    ]),
     AuthModule,
     UsersModule,
     KickboardsModule,
@@ -30,8 +39,9 @@ import { RegularPolicy } from './regular-policies/regular-policy';
     CalculatorModule,
     RegularPolicesModule,
     ForbiddenAreaModule,
+    ParkingZoneModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -5,18 +5,23 @@ import { Area } from './area/area.entity';
 import { Kickboard } from './kickboards/kickboard.entity';
 import { RegularPoliciesService } from './regular-policies/regular-policies.service';
 import { RegularPolicy } from './regular-policies/regular-policy';
+import { ParkingZone } from './parking-zone/parking-zone.entity';
+import { ForbiddenArea } from './forbidden-area/forbidden-area.entity';
 
 @Injectable()
 export class AppService implements OnApplicationBootstrap {
-
   constructor(
     @InjectRepository(Area)
     private readonly areaRepository: Repository<Area>,
     @InjectRepository(Kickboard)
     private readonly kickboardRepository: Repository<Kickboard>,
     @InjectRepository(RegularPolicy)
-    private readonly regularPolicyRepository: Repository<RegularPolicy>
-  ) { }
+    private readonly regularPolicyRepository: Repository<RegularPolicy>,
+    @InjectRepository(ParkingZone)
+    private readonly parkingZoneRepository: Repository<ParkingZone>,
+    @InjectRepository(ForbiddenArea)
+    private readonly forbiddenAreaRepository: Repository<ForbiddenArea>,
+  ) {}
 
   getHello(): string {
     return 'Hello World!';
@@ -42,7 +47,7 @@ export class AppService implements OnApplicationBootstrap {
       (
         '건대', 
         ST_GEOMFROMTEXT(
-          'POLYGON((0 0, 2 0, 11 11, 0 2, 0 0))'
+          'POLYGON(( 37.571562 127.080008, 37.570788 127.086038, 37.558816 127.087727, 37.554418 127.094311, 37.550332 127.091142, 37.548932 127.093407, 37.544818 127.090204, 37.544015 127.107361, 37.527082 127.085368, 37.538147 127.043375, 37.550774 127.041713, 37.548957 127.062508, 37.571562 127.080008))'
         ),
         ST_GEOMFROMTEXT('POINT(37.562057 127.096092)'), 
         ST_GEOMFROMTEXT(
@@ -63,11 +68,39 @@ export class AppService implements OnApplicationBootstrap {
       .insert()
       .into(RegularPolicy)
       .values([
-        { id: "건대", basic: 3000, ratePerMinute: 300 },
-        { id: "여수", basic: 4000, ratePerMinute: 400 },
+        { id: '건대', basic: 3000, ratePerMinute: 300 },
+        { id: '여수', basic: 4000, ratePerMinute: 400 },
       ])
       .orIgnore()
       .execute();
+
+    const parkingZone = this.parkingZoneRepository.query(
+      `INSERT IGNORE INTO parking_zone(id, parkingzone_center_lat, parkingzone_center_lng, parkingzone_radius, areaId) VALUES
+       (1, 37.547005, 127.074779, 0.05, '건대'),
+       (2, 37.541134, 127.073721, 0.05, '건대'),
+       (3, 37.544263, 127.057211, 0.05, '건대'),
+       (4, 37.539386, 127.053021, 0.05, '건대')`,
+    );
+
+    const forbiddenArea = this.forbiddenAreaRepository.query(
+      `INSERT IGNORE INTO forbidden_area(id, forbiddenAreaBoundary, forbiddenAreaCoords, areaId) VALUES
+      (
+        '건대1', 
+        ST_GEOMFROMTEXT(
+          'POLYGON(( 37.551938 127.076721, 37.552133 127.089132, 37.545142 127.085223, 37.545448 127.079719, 37.551938 127.076721))'
+        ),
+        ST_GEOMFROMTEXT('LINESTRING(37.551938 127.076721, 37.552133 127.089132, 37.545142 127.085223, 37.545448 127.079719, 37.551938 127.076721)'),
+        '건대'
+      ),
+      (
+        '건대2', 
+        ST_GEOMFROMTEXT(
+          'POLYGON( (37.538488 127.071729, 37.537754 127.074005, 37.536153 127.073489, 37.536972 127.071077, 37.538488 127.071729) )'
+        ), 
+        ST_GEOMFROMTEXT('LINESTRING(37.538488 127.071729, 37.537754 127.074005, 37.536153 127.073489, 37.536972 127.071077, 37.538488 127.071729)'),
+        '건대'
+      )`,
+    );
 
     return 'insert executed';
   }

--- a/src/parking-zone/parking-zone.entity.ts
+++ b/src/parking-zone/parking-zone.entity.ts
@@ -1,10 +1,10 @@
 import { Area } from 'src/area/area.entity';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryColumn, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class ParkingZone {
   @PrimaryGeneratedColumn()
-  parkingzone_id: number;
+  id: number;
 
   @Column({ type: 'decimal', precision: 18, scale: 10 })
   parkingzone_center_lat: number; // 위도
@@ -15,6 +15,6 @@ export class ParkingZone {
   @Column({ type: 'float' })
   parkingzone_radius: number;
 
-  // @ManyToOne(() => Area)
-  // area: Area;
+  @ManyToOne(() => Area)
+  area: Area;
 }

--- a/src/parking-zone/parking-zone.module.ts
+++ b/src/parking-zone/parking-zone.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ParkingZone } from './parking-zone.entity';
+import { ParkingZoneService } from './parking-zone.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ParkingZone])],
+  exports: [ParkingZoneService],
+  providers: [ParkingZoneService],
+})
+export class ParkingZoneModule {}

--- a/src/parking-zone/parking-zone.service.ts
+++ b/src/parking-zone/parking-zone.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ParkingZone } from './parking-zone.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class ParkingZoneService {
+  constructor(
+    @InjectRepository(ParkingZone)
+    private readonly parkingZoneRepository: Repository<ParkingZone>,
+  ) {}
+  //
+  async exists(user_lat, user_lng): Promise<boolean> {
+    const query = `
+    SELECT * ,
+      (6371*ACOS(COS(RADIANS( ${user_lat} ))
+      *COS(RADIANS(parkingzone_center_lat))
+      *COS(RADIANS(parkingzone_center_lng)-RADIANS( ${user_lng} ))
+      +SIN(RADIANS( ${user_lat} ))*SIN(RADIANS(parkingzone_center_lat))))
+     AS distance
+     FROM parking_zone
+     HAVING distance <= parkingzone_radius`;
+
+    const result = await this.parkingZoneRepository.query(query);
+    if (result.length >= 1) {
+      return true; // 파킹존 안에 존재
+    } else {
+      return false; // 파킹존 아님
+    }
+  }
+}


### PR DESCRIPTION
## 작업사항
parking-zone 모듈과 서비스 파일 생성.
parking-zone 서비스 파일안에 exists( ) 사용자의 위도, 경도를 받아 파킹존 안에 있는지 판단 메서드 만듬.
app 서비스에 DB 초기값 설정 (parking-zone, forbidden-area) 값 추가